### PR TITLE
HTTP encapsulation and proxy support

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,8 @@ QUICKSTART
 - To view data logged to a file by prox.py, use proxcat:
    - $ ./proxcat.py -x log.txt
 
+- Use an external HTTP proxy in order to edit the information:
+   - $ ./prox.py -L 1337 -p 127.0.0.1:8080 tcpsrv.test.com 1337 
 
 DEPENDENCIES
 =======

--- a/prox.py
+++ b/prox.py
@@ -162,6 +162,16 @@ class Half(object) :
         self.err = "error on " + self.name
         return self.err
 
+
+    def customEncode(self, buf) :
+        params = urllib.urlencode({'payload': buf})
+        for c in ['<', '>', '(', ')', ':', '@', ' ', '"', '\'', '/', '\\', '*', '=', '\n' ] :
+            ce = '%' + c.encode('hex')
+            params = params.replace(ce.lower(),c)
+            params = params.replace(ce.upper(),c)        
+        params = params.replace('+',' ')
+        return params
+
     def writeSome(self) :
         try :
             n = self.sock.send(self.queue[0])
@@ -211,7 +221,7 @@ class Half(object) :
                 srcport = str(self.opt.port)
                 dstip = self.addr[0]
                 dstport = str(self.addr[1])
-            params = urllib.urlencode({'payload': buf})
+            params = self.customEncode(buf)
             [proxyHost, proxyPort] = self.opt.httpProxy.split(":")
             conn = httplib.HTTPConnection(proxyHost, proxyPort)
             conn.request("POST", "http://"+self.opt.callbackHost+":"+str(self.opt.callbackPort)+'/'+srcip+':'+srcport+'/'+dstip+':'+dstport, params)


### PR DESCRIPTION
TCP payload is encoded and sent to an HTTP Proxy. Then you can edit the content or use any other features (intruder/repeater in Burp, for example).

It binds a new callback HTTP service that is necessary to receive the modified content from the HTTP server.