### PR TITLE
SO_ORIGINAL_DST

### DIFF
--- a/docs/prox.txt
+++ b/docs/prox.txt
@@ -5,7 +5,7 @@ NAME
 SYNOPSIS
     prox.py [opts] addr port
     prox.py [opts] -s [-C cert] [-A cname] addr port
-    opts: [-1] [-6] [-b bindaddr] [-L localport] [-l logfile] [-m mod:args] [--ssl-in] [--ssl-out] [-3] [-T]
+    opts: [-1] [-6] [-b bindaddr] [-L localport] [-l logfile] [-m mod:args] [--ssl-in] [--ssl-out] [-3] [-T] [-O]
 
 DESCRIPTION
     The prox.py tool provides a TCP proxy that proxies data between
@@ -14,7 +14,7 @@ DESCRIPTION
     host to establish a connection to. If the -6 argument is given
     all addresses are treated as IPv6 addresses, otherwise as IPv4
     addresses. When IPv6 is used, the proxy will attempt to enable
-    IPv4-in-IPv6 compatibility if it is supported by the operating 
+    IPv4-in-IPv6 compatibility if it is supported by the operating
     system.
 
     The prox.py tool will listen on for connections to the port port
@@ -23,6 +23,12 @@ DESCRIPTION
     Normally the program will accept any number of TCP connections
     and proxy them all (possibly concurrently) unless the -1 option
     is given, in which case only one connection is processed.
+
+    The option -O relies on SO_ORIGINAL_DST option set on the client
+    socket by iptables REDIRECT target to get the original destination.
+    This options does not need (and even ignores) addr and port arguments.
+    -O (without -1) allows a single process to proxy connections to
+    multiple destinations. As it relies on iptables, it is Linux-only.
 
     If a log filename is specified with the -l option, all data
     proxied by the program will be written out to the specified log
@@ -95,7 +101,7 @@ EXAMPLES
         $ ./prox.py -s -A www.evil.com -C myca -l log.txt 1.2.3.4 443
 
     Proxy incoming data connections to port 8888 over IPv4 or IPv6
-    to port 80 of the 173.194.64.147 IPv4 address. Notice that an 
+    to port 80 of the 173.194.64.147 IPv4 address. Notice that an
     IPv4-in-IPv6 address is used to specify the target.
 
         $ ./prox.py -6 -L 8888 ::ffff:173.194.64.147 80
@@ -105,6 +111,12 @@ EXAMPLES
     the client to uppercase:
 
         $ ./prox.py -m modFiltCase:dummyArg 1.2.3.4 1234
+
+    Proxy multiple connections on a NAT system with iptables (transparent-proxy like):
+        $ sudo iptables -t nat -A PREROUTING -p tcp --dport 9001 -j REDIRECT --to 8888
+        $ sudo iptables -t nat -A PREROUTING -p tcp --dport 80 -j REDIRECT --to 8888
+        $ ./prox.py -L 8888 -O
+
 
 BUGS
     The SSL handshake is performed synchronously for implementation


### PR DESCRIPTION
Option *-O* to use client socket connection SO_ORIGINAL_DST instead of script arguments (for the server side connection).

This can be useful for generic *iptables* redirects as for some applications I've debugged, they connect to different servers but always on the same port.

Using something like

```
sudo iptables -t nat -A PREROUTING -p tcp --dport 9001 -j REDIRECT --to 8888
./prox.py -L 8888 -C ca -s -l that.log
```

Will work no matter the destination IP (and it's lazy-friendly as well :))